### PR TITLE
add: engine to code coverage all tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+coverage

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -5,6 +5,20 @@ const config: Config = {
   testEnvironment: "jsdom",
   setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
   moduleFileExtensions: ["ts", "tsx", "js", "jsx"],
+  coverageDirectory: "/coverage",
+  coverageReporters: [
+    "text",
+    "html",
+    "lcov"
+  ],
+  coverageThreshold: {
+    global: {
+      branches: 90,
+      functions: 90,
+      lines: 90,
+      statements: 90,
+    },
+  },
 };
 
 export default config;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "jest"
+    "test": "jest",
+    "coverage": "jest --coverage"
   },
   "dependencies": {
     "react": "^19.1.1",


### PR DESCRIPTION
## 📝 Descrição
Adicionado code coverage para a execução dos testes

## 🔑 Alterações principais
- [x] Code coverage agora é gerado por um comando `pnpm coverage`
- [x] Pasta de coverage é ignorada no versionamento

## 🧪 Testes realizados
- [x] Execução do comando de coverage para gerar a cobertura de código

## 📚 Notas adicionais
Não há demais notas
